### PR TITLE
WIP: prevent duplication/worker timeouts for long-running tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --no-cache python3 python3-dev ca-certificates
+RUN apk add --no-cache python3 python3-dev ca-certificates gcc g++
 
 # Copy app over
 COPY . /src/

--- a/listener.py
+++ b/listener.py
@@ -102,7 +102,7 @@ class Listener(Utils):
                     if help_response is not None:
                         response['attachments'].extend(help_response)
 
-            if response.get('thread_reply') is True or message_data.get('thread_ts') is not None or is_help_message is True:
+            if response.get('thread_reply') is True or message_data.get('thread_ts') is not None or is_help_message is True: # noqa
                 # Reply to the message using a thread
                 response['thread_ts'] = message_data.get('thread_ts', message_data['ts'])
                 try:
@@ -123,6 +123,7 @@ class Listener(Utils):
 
             if response.get('add_to_queue') is True:
                 try:
+                    full_data['attempt'] = 1
                     self.mq.basic_publish(exchange='',
                                           routing_key=self.mq_name,
                                           body=json.dumps(full_data))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pandas>=0.22.0
 parse>=1.8.0
 pika>=0.10.0
 PyYAML>=3.12

--- a/worker.py
+++ b/worker.py
@@ -23,7 +23,7 @@ class Worker(Utils):
                     'thread_reply': False,  # Only here for the response, does not get passed to the api call
                     }
 
-        # Remove the message from the queue imme
+        # Remove the message from the queue immediately
         ch.basic_ack(delivery_tag=method.delivery_tag)
 
         try:

--- a/worker.py
+++ b/worker.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import traceback
 from utils import Utils
 
 logger = logging.getLogger(__name__)
@@ -57,9 +58,9 @@ class Worker(Utils):
             if len(response.get('text', '').strip()) > 0 or len(response.get('attachments', [])) > 0:
                 # Only post a message if needed. Reason not to would be the item got queued
                 self.slack_client.api_call("chat.postMessage", **response)
-        except Exception as e:
+        except Exception:
             # if message is not processed properly, put it back in the queue
-            logger.error(str(e))
+            logger.error(traceback.format_exc())
             if full_data['attempt'] < 3:
                 full_data['attempt'] += 1
                 logger.info('Putting message back in queue for retry.')

--- a/worker.py
+++ b/worker.py
@@ -60,5 +60,9 @@ class Worker(Utils):
         except Exception as e:
             # if message is not processed properly, put it back in the queue
             logger.error(str(e))
-            logger.info('Putting message back in queue for retry.')
-            self.mq.basic_publish(exchange='', routing_key=self.mq_name, body=json.dumps(full_data))
+            if full_data['attempt'] < 3:
+                full_data['attempt'] += 1
+                logger.info('Putting message back in queue for retry.')
+                self.mq.basic_publish(exchange='', routing_key=self.mq_name, body=json.dumps(full_data))
+            else:
+                logger.info('Unable to complete task after 3 tries.')

--- a/worker.py
+++ b/worker.py
@@ -60,6 +60,7 @@ class Worker(Utils):
                 self.slack_client.api_call("chat.postMessage", **response)
         except Exception:
             # if message is not processed properly, put it back in the queue
+            # TODO: this isn't working if the error happens late in a long-running task
             logger.error(traceback.format_exc())
             if full_data['attempt'] < 3:
                 full_data['attempt'] += 1

--- a/worker.py
+++ b/worker.py
@@ -23,36 +23,42 @@ class Worker(Utils):
                     'thread_reply': False,  # Only here for the response, does not get passed to the api call
                     }
 
-        for command_name in self.channel_to_actions[full_data['channel']['name']]:
-            command = self.commands[command_name]
-
-            parsed_response = command.p.parse(full_data['message']['text'], full_post=full_data)
-            if parsed_response is not None:
-                response.update(parsed_response)
-                break
-
-        if response.get('thread_reply') is True or full_data['message'].get('thread_ts') is not None:
-            # Reply to the message using a thread
-            response['thread_ts'] = full_data['message'].get('thread_ts', full_data['message']['ts'])
-            try:
-                del response['thread_reply']  # Cannot be passed to the api_call fn
-            except KeyError:
-                pass
-
-        if response.get('reaction', '') != '':
-            self.slack_client.api_call("reactions.add",
-                                       channel=full_data['channel']['id'],
-                                       name=response['reaction'],
-                                       timestamp=full_data['message']['ts']
-                                       )
-            try:
-                del response['reaction']  # Cannot be passed to the api_call fn
-            except KeyError:
-                pass
-
-        if len(response.get('text', '').strip()) > 0 or len(response.get('attachments', [])) > 0:
-            # Only post a message if needed. Reason not to would be the item got queued
-            self.slack_client.api_call("chat.postMessage", **response)
-
-        # Remove the messge from the queue
+        # Remove the message from the queue imme
         ch.basic_ack(delivery_tag=method.delivery_tag)
+
+        try:
+            for command_name in self.channel_to_actions[full_data['channel']['name']]:
+                command = self.commands[command_name]
+
+                parsed_response = command.p.parse(full_data['message']['text'], full_post=full_data)
+                if parsed_response is not None:
+                    response.update(parsed_response)
+                    break
+
+            if response.get('thread_reply') is True or full_data['message'].get('thread_ts') is not None:
+                # Reply to the message using a thread
+                response['thread_ts'] = full_data['message'].get('thread_ts', full_data['message']['ts'])
+                try:
+                    del response['thread_reply']  # Cannot be passed to the api_call fn
+                except KeyError:
+                    pass
+
+            if response.get('reaction', '') != '':
+                self.slack_client.api_call("reactions.add",
+                                           channel=full_data['channel']['id'],
+                                           name=response['reaction'],
+                                           timestamp=full_data['message']['ts']
+                                           )
+                try:
+                    del response['reaction']  # Cannot be passed to the api_call fn
+                except KeyError:
+                    pass
+
+            if len(response.get('text', '').strip()) > 0 or len(response.get('attachments', [])) > 0:
+                # Only post a message if needed. Reason not to would be the item got queued
+                self.slack_client.api_call("chat.postMessage", **response)
+        except Exception as e:
+            # if message is not processed properly, put it back in the queue
+            logger.error(str(e))
+            logger.info('Putting message back in queue for retry.')
+            self.mq.basic_publish(exchange='', routing_key=self.mq_name, body=json.dumps(full_data))


### PR DESCRIPTION
moved the message ack to before the task code and added a try/except that puts the message back into the queue if there is an error. this will at least prevent long running tasks from being duplicated. the specifics of the try/except are definitely up for debate - just wrapped all the tasks and response code and caught all errors to be safe. 

it also might still break depending on how far into the long-running task the error happens, it's not clear what the timeout behavior will be like when using basic_publish